### PR TITLE
fix: brew-dump をスマートマージ方式に変更してフォーマットを保持

### DIFF
--- a/.config/homebrew/Brewfile
+++ b/.config/homebrew/Brewfile
@@ -45,3 +45,10 @@ brew "htop"              # インタラクティブなプロセスビューア
 brew "zsh-autosuggestions"
 brew "zsh-completions"
 brew "zsh-syntax-highlighting"
+
+# newly added (2026-03-31)
+brew "ffmpeg"
+brew "parallel"
+brew "qpdf"
+brew "tesseract"
+brew "tesseract-lang"

--- a/.config/homebrew/Brewfile.cask
+++ b/.config/homebrew/Brewfile.cask
@@ -22,3 +22,6 @@ cask "obsidian"
 cask "visual-studio-code"
 cask "vlc"
 cask "zoom"
+
+# newly added (2026-03-31)
+cask "kiro"

--- a/.config/homebrew/Brewfile.mas
+++ b/.config/homebrew/Brewfile.mas
@@ -7,3 +7,6 @@ mas "LINE", id: 539883307
 mas "Numbers", id: 409203825
 mas "Pages", id: 409201541
 mas "Slack", id: 803453959
+
+# newly added (2026-03-31)
+mas "Actions"

--- a/.config/homebrew/Brewfile.vscode
+++ b/.config/homebrew/Brewfile.vscode
@@ -42,3 +42,6 @@ vscode "vscode-icons-team.vscode-icons"
 vscode "wmaurer.change-case"
 vscode "yzane.markdown-pdf"
 vscode "yzhang.markdown-all-in-one"
+
+# newly added (2026-03-31)
+vscode "anthropic.claude-code"

--- a/scripts/brew_dumps.sh
+++ b/scripts/brew_dumps.sh
@@ -1,27 +1,160 @@
 #!/bin/bash
-# brew_dumps.sh - 現在の Homebrew インストール状態を Brewfile にバックアップ
+# brew_dumps.sh - 現在の Homebrew インストール状態を Brewfile にスマートマージ
+#
+# 既存ファイルのコメント・カテゴリ構造を保持したまま、
+# 新規追加エントリのみを末尾に追記する。
+# 削除候補（インストール済みリストから消えたエントリ）は警告表示のみ行い、
+# 手動での対応を促す。
 
 set -euo pipefail
 
 CONFIG_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/homebrew"
+TMPDIR="${TMPDIR:-/tmp}"
+TODAY=$(date +%Y-%m-%d)
 
-echo ">>> Homebrew の状態を $CONFIG_DIR にエクスポートします..."
+# 一時ファイルを作成し、スクリプト終了時に自動削除する
+TMPFILE_BREWS=$(mktemp "${TMPDIR}/brew_dump_brews.XXXXXX")
+TMPFILE_CASK=$(mktemp "${TMPDIR}/brew_dump_cask.XXXXXX")
+TMPFILE_TAPS=$(mktemp "${TMPDIR}/brew_dump_taps.XXXXXX")
+TMPFILE_MAS=$(mktemp "${TMPDIR}/brew_dump_mas.XXXXXX")
+TMPFILE_VSCODE=$(mktemp "${TMPDIR}/brew_dump_vscode.XXXXXX")
+trap 'rm -f "$TMPFILE_BREWS" "$TMPFILE_CASK" "$TMPFILE_TAPS" "$TMPFILE_MAS" "$TMPFILE_VSCODE"' EXIT
 
-brew bundle dump --force --brews   --file="$CONFIG_DIR/Brewfile"
-echo "    ✓ Brewfile"
+echo ">>> Homebrew の状態を取得します..."
+brew bundle dump --force --brews   --file="$TMPFILE_BREWS"
+brew bundle dump --force --cask    --file="$TMPFILE_CASK"
+brew bundle dump --force --taps    --file="$TMPFILE_TAPS"
+brew bundle dump --force --mas     --file="$TMPFILE_MAS"
+brew bundle dump --force --vscode  --file="$TMPFILE_VSCODE"
+echo "    ✓ 取得完了"
+echo ""
 
-brew bundle dump --force --cask    --file="$CONFIG_DIR/Brewfile.cask"
-echo "    ✓ Brewfile.cask"
+# -----------------------------------------------------------------
+# extract_names <file> <prefix>
+#   Brewfile から各エントリ名（引用符内の文字列）を抽出する
+#   例: brew "bat"  → bat
+#       cask "iterm2" → iterm2
+# -----------------------------------------------------------------
+extract_names() {
+    local file="$1"
+    local prefix="$2"
+    grep "^${prefix} " "$file" | sed -E "s/^${prefix} \"([^\"]+)\".*/\1/" | sort
+}
 
-brew bundle dump --force --taps    --file="$CONFIG_DIR/Brewfile.taps"
-echo "    ✓ Brewfile.taps"
+# -----------------------------------------------------------------
+# merge_brewfile <existing_file> <dump_file> <prefix> <label>
+#   既存ファイルと dump の差分を計算し、新規エントリを追記する。
+#   削除候補は stderr に警告を出す。
+# -----------------------------------------------------------------
+merge_brewfile() {
+    local existing="$1"
+    local dumped="$2"
+    local prefix="$3"
+    local label="$4"
 
-brew bundle dump --force --mas     --file="$CONFIG_DIR/Brewfile.mas"
-echo "    ✓ Brewfile.mas"
+    # 既存ファイルがなければ dump をそのままコピー
+    if [[ ! -f "$existing" ]]; then
+        cp "$dumped" "$existing"
+        echo "    ✓ ${label}: 新規作成"
+        return
+    fi
 
-brew bundle dump --force --vscode  --file="$CONFIG_DIR/Brewfile.vscode"
-echo "    ✓ Brewfile.vscode"
+    local existing_names
+    existing_names=$(extract_names "$existing" "$prefix")
+    local dumped_names
+    dumped_names=$(extract_names "$dumped" "$prefix")
+
+    # 新規追加分（dump にあって existing にない）
+    local added
+    added=$(comm -13 <(echo "$existing_names") <(echo "$dumped_names") || true)
+
+    # 削除候補（existing にあって dump にない）
+    local removed
+    removed=$(comm -23 <(echo "$existing_names") <(echo "$dumped_names") || true)
+
+    local changed=false
+
+    if [[ -n "$added" ]]; then
+        {
+            echo ""
+            echo "# newly added (${TODAY})"
+            while IFS= read -r name; do
+                echo "${prefix} \"${name}\""
+            done <<< "$added"
+        } >> "$existing"
+        changed=true
+        local count
+        count=$(echo "$added" | wc -l | tr -d ' ')
+        echo "    ✓ ${label}: ${count} 件追加"
+        while IFS= read -r name; do
+            echo "       + ${name}"
+        done <<< "$added"
+    fi
+
+    if [[ -n "$removed" ]]; then
+        echo "    ⚠ ${label}: 以下は現在アンインストール済みです（手動で削除してください）:"
+        while IFS= read -r name; do
+            echo "       - ${name}"
+        done <<< "$removed"
+    fi
+
+    if [[ "$changed" == false ]] && [[ -z "$removed" ]]; then
+        echo "    ✓ ${label}: 変更なし"
+    fi
+}
+
+# -----------------------------------------------------------------
+# merge_taps <existing_file> <dump_file>
+#   taps はコメントなしのシンプル構造なのでエントリ単位でマージする
+# -----------------------------------------------------------------
+merge_taps() {
+    local existing="$1"
+    local dumped="$2"
+
+    if [[ ! -f "$existing" ]]; then
+        cp "$dumped" "$existing"
+        echo "    ✓ Brewfile.taps: 新規作成"
+        return
+    fi
+
+    local existing_taps dumped_taps added removed
+    existing_taps=$(grep "^tap " "$existing" | sort || true)
+    dumped_taps=$(grep "^tap " "$dumped" | sort || true)
+
+    added=$(comm -13 <(echo "$existing_taps") <(echo "$dumped_taps") || true)
+    removed=$(comm -23 <(echo "$existing_taps") <(echo "$dumped_taps") || true)
+
+    if [[ -n "$added" ]]; then
+        {
+            echo ""
+            echo "# newly added (${TODAY})"
+            echo "$added"
+        } >> "$existing"
+        local count
+        count=$(echo "$added" | wc -l | tr -d ' ')
+        echo "    ✓ Brewfile.taps: ${count} 件追加"
+    fi
+
+    if [[ -n "$removed" ]]; then
+        echo "    ⚠ Brewfile.taps: 以下は削除候補（手動で確認してください）:"
+        while IFS= read -r line; do
+            echo "       - ${line}"
+        done <<< "$removed"
+    fi
+
+    if [[ -z "$added" ]] && [[ -z "$removed" ]]; then
+        echo "    ✓ Brewfile.taps: 変更なし"
+    fi
+}
+
+echo ">>> 差分をマージしています..."
+merge_brewfile "$CONFIG_DIR/Brewfile"         "$TMPFILE_BREWS"  "brew"   "Brewfile"
+merge_brewfile "$CONFIG_DIR/Brewfile.cask"    "$TMPFILE_CASK"   "cask"   "Brewfile.cask"
+merge_brewfile "$CONFIG_DIR/Brewfile.mas"     "$TMPFILE_MAS"    "mas"    "Brewfile.mas"
+merge_brewfile "$CONFIG_DIR/Brewfile.vscode"  "$TMPFILE_VSCODE" "vscode" "Brewfile.vscode"
+merge_taps     "$CONFIG_DIR/Brewfile.taps"    "$TMPFILE_TAPS"
 
 echo ""
-echo ">>> エクスポート完了。変更をコミットして管理してください:"
-echo "    git -C \$(git rev-parse --show-toplevel) add .config/homebrew/ && git commit -m 'brew: update Brewfiles'"
+echo ">>> マージ完了。変更をレビューしてコミットしてください:"
+echo "    git diff .config/homebrew/"
+echo "    git add .config/homebrew/ && git commit -m 'brew: update Brewfiles'"


### PR DESCRIPTION
## Summary

- `brew bundle dump --force` による全上書きをやめ、**既存 Brewfile のコメント・カテゴリ構造を保持したまま新規エントリのみ末尾に追記**する方式に変更
- アンインストール済みパッケージは警告表示のみとし、手動削除を促す（自動削除しない）
- 一時ファイルへの dump → 差分比較 → スマートマージ の3ステップで動作

## 変更の動作イメージ

\`\`\`
>>> 差分をマージしています...
    ✓ Brewfile: 3 件追加
       + ffmpeg
       + parallel
       + tesseract
    ⚠ Brewfile: 以下は現在アンインストール済みです（手動で削除してください）:
       - some-old-package
    ✓ Brewfile.cask: 変更なし
\`\`\`

## Test plan

- [ ] \`make brew-dump\` を実行してコメント・カテゴリが保持されることを確認
- [ ] 新規インストール済みパッケージが \`# newly added (YYYY-MM-DD)\` セクションとして末尾に追記されることを確認
- [ ] \`make shellcheck\` が通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)