### PR TITLE
fix: make setup がgit追跡ファイルを汚染する問題を修正

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -151,7 +151,7 @@ clean-dry: ## クリーンアップの対象を表示するだけ（実際には
 
 .PHONY: git-hooks
 git-hooks: ## グローバル Git フック（core.hooksPath）を設定する
-	git config --global core.hooksPath "$$HOME/.config/git/hooks"
+	git config --global core.hooksPath '~/.config/git/hooks'
 	@echo "  ✓ core.hooksPath = $$(git config --global core.hooksPath)"
 	@echo "  ✓ Conventional Commits フックが有効になりました"
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -49,11 +49,6 @@ fi
 eval "$($BREW_PREFIX/bin/brew shellenv)"
 brew --version
 
-BREW_PATH_LINE="export PATH=$BREW_PREFIX/bin:\$PATH"
-if ! grep -qF "$BREW_PATH_LINE" "$HOME/.config/zsh/.zshrc" 2>/dev/null; then
-  echo "$BREW_PATH_LINE" >> "$HOME/.config/zsh/.zshrc"
-fi
-
 # ----- セットアップに必要なツール -----
 echo ">>> Installing yq..."
 brew install yq


### PR DESCRIPTION
## 問題

`make setup` を実行するたびに以下の2ファイルがgit管理状態から変更されてしまっていた。

```diff
# .config/git/config
-	hooksPath = ~/.config/git/hooks
+	hooksPath = /Users/chikafumi/.config/git/hooks

# .config/zsh/.zshrc
+export PATH=/opt/homebrew/bin:$PATH
```

## 原因

### `.config/git/config` の汚染
`Makefile` の `git-hooks` ターゲットで `$$HOME/.config/git/hooks` を使用していたため、シェルが `$HOME` を絶対パスに展開して書き込んでいた。`~/.config/git/config` はシンボリックリンクなので、dotfilesリポジトリの追跡ファイルが直接書き換えられていた。

### `.zshrc` の汚染
`scripts/install.sh` が `export PATH=/opt/homebrew/bin:$PATH` を `.zshrc` に追記していた。`.zshrc` はすでに `eval "$(brew shellenv)"` でHomebrewのPATHを設定済みのため冗長であり、`make link` 後はシンボリックリンク先のgit追跡ファイルが汚染されていた。

## 修正

- **`Makefile`**: `"$$HOME/.config/git/hooks"` → `'~/.config/git/hooks'`（チルダ形式で保存されるようにシングルクォートに変更）
- **`scripts/install.sh`**: `BREW_PATH_LINE` ブロックを削除（`.zshrc` の `eval "$(brew shellenv)"` で代替済み）

## テスト

- [ ] `make git-hooks` 後に `.config/git/config` の差分がないこと
- [ ] `make setup` 後に `.config/zsh/.zshrc` の差分がないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)