### PR TITLE
feat: GitHub Actions ワークフローに actionlint を追加（path filter 付き）

### DIFF
--- a/.github/workflows/actionlint.yaml
+++ b/.github/workflows/actionlint.yaml
@@ -22,4 +22,4 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Run actionlint
-        uses: rhysd/actionlint@v1
+        uses: rhysd/actionlint@v1.7.12

--- a/.github/workflows/actionlint.yaml
+++ b/.github/workflows/actionlint.yaml
@@ -1,0 +1,25 @@
+name: actionlint
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - '.github/workflows/**'
+  pull_request:
+    branches: [ main ]
+    paths:
+      - '.github/workflows/**'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  actionlint:
+    name: Lint GitHub Actions workflows
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run actionlint
+        uses: rhysd/actionlint@v1


### PR DESCRIPTION
## Summary

- `.github/workflows/actionlint.yaml` を新規作成
- `.github/workflows/**` が変更されたときだけ動作するように `on.push.paths` / `on.pull_request.paths` で path filter を設定
- `rhysd/actionlint@v1` で GitHub Actions YAML を lint

## 変更内容

| ファイル | 変更 |
|----------|------|
| `.github/workflows/actionlint.yaml` | 新規作成 |

## Test plan

- [ ] `.github/workflows/` 以外のファイル変更では actionlint ジョブがスキップされることを確認
- [ ] `.github/workflows/` 内のファイルを変更すると actionlint ジョブが動作することを確認
- [ ] actionlint が既存ワークフロー（`macos.yaml`, `validate.yaml`, `actionlint.yaml`）にエラーを出さないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)