### PR TITLE
fix: GPG keyboxd バージョン不一致でキーインポートが失敗する問題を修正

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,8 @@ sheldon: ## sheldon（Zsh プラグインマネージャー）を初期化
 .PHONY: mise-install
 mise-install: ## mise で管理するツール（node・python・go・terraform）をインストール
 	@echo ">>> Node.js GPG 署名検証キーをインポートしています..."
+	@# keyboxd のバージョン不一致を防ぐため、古いデーモンを終了させる
+	@gpgconf --kill keyboxd 2>/dev/null || true
 	@# Node.js リリースチームのキーを openpgp.org から取得（失敗時は ubuntu keyserver にフォールバック）
 	@gpg --keyserver hkps://keys.openpgp.org --recv-keys \
 	  C0D6248439F1D5604AAFFB4021D900FFDB233756 \


### PR DESCRIPTION
## Summary

- `make setup` / `make mise-install` 実行時に `gpg: 署名を検査できません: 公開鍵がありません` エラーが発生する問題を修正
- Homebrew gpg (2.5.18) と古い keyboxd デーモン (2.4.9) のバージョン不一致が原因
- `gpg --recv-keys` 実行前に `gpgconf --kill keyboxd` で古いデーモンを終了させることで解消

## Root Cause

`gpg --recv-keys ... 2>&1 | grep -v "keyboxd"` のパイプ構造により:
1. keyboxd バージョン不一致 → gpg がキーリングへの書き込みに失敗
2. すべての出力が "keyboxd" を含む → grep が全行フィルタ → exit 1
3. フォールバックの ubuntu keyserver も同様に失敗
4. `|| true` でエラー無視 → キー未インポートのまま `mise install` 実行
5. mise が Node.js アーカイブの GPG 検証に失敗

## Fix

`gpgconf --kill keyboxd 2>/dev/null || true` を gpg コマンド実行前に追加し、
古いデーモンを終了させる。次の gpg 実行時に新バージョンの keyboxd が自動起動される。

## Test plan

- [ ] `make mise-install` でエラーなく node/python/go/terraform がインストールされることを確認
- [ ] CI (macOS Setup Test) が通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)