### PR TITLE
fix: gpg-agent も含む全デーモンを kill して keyboxd バージョン不一致を解消

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,8 +42,9 @@ sheldon: ## sheldon（Zsh プラグインマネージャー）を初期化
 .PHONY: mise-install
 mise-install: ## mise で管理するツール（node・python・go・terraform）をインストール
 	@echo ">>> Node.js GPG 署名検証キーをインポートしています..."
-	@# keyboxd のバージョン不一致を防ぐため、古いデーモンを終了させる
-	@gpgconf --kill keyboxd 2>/dev/null || true
+	@# gpg-agent/keyboxd のバージョン不一致を防ぐため、全デーモンを終了させる
+	@# （gpg-agent が生存したまま --kill keyboxd すると 2.4.9 の keyboxd が再起動される）
+	@gpgconf --kill all 2>/dev/null || true
 	@# Node.js リリースチームのキーを openpgp.org から取得（失敗時は ubuntu keyserver にフォールバック）
 	@gpg --keyserver hkps://keys.openpgp.org --recv-keys \
 	  C0D6248439F1D5604AAFFB4021D900FFDB233756 \


### PR DESCRIPTION
## Summary

- `--kill keyboxd` のみでは gpg-agent が残存し、古い 2.4.9 の keyboxd を即座に再起動してしまう
- gpg 自身のエラーメッセージ (`gpgconf --kill all を使って再起動してください`) に従い `--kill all` に変更

## Root Cause Analysis

```
# 旧動作 (--kill keyboxd)
gpgconf --kill keyboxd  # keyboxd (2.4.9) を停止
gpg --recv-keys ...     # gpg-agent (2.4.9) がまだ動いている → keyboxd 2.4.9 を再起動
                        # gpg 2.5.18 が keyboxd 2.4.9 に接続 → バージョン不一致継続
```

```
# 新動作 (--kill all)
gpgconf --kill all      # gpg-agent も keyboxd も全停止
gpg --recv-keys ...     # gpg-agent 2.5.18 が新たに起動 → keyboxd 2.5.18 を起動
                        # バージョン一致 → キーインポート成功
mise install            # 同じ 2.5.18 デーモンで GPG 検証 → 成功
```

## Test plan

- [ ] `make mise-install` でエラーなく完了することを確認
- [ ] CI (macOS Setup Test) が通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)