### PR TITLE
fix: mise-install 後の npm/claude コマンドが見つからない問題を修正

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,7 +130,7 @@ uninstall-gcloud: ## Google Cloud SDK をアンインストール
 
 .PHONY: install-claude-code
 install-claude-code: ## Claude Code（Anthropic CLI）をインストール
-	./scripts/install_claude_code.sh
+	mise exec -- ./scripts/install_claude_code.sh
 
 .PHONY: uninstall-claude-code
 uninstall-claude-code: ## Claude Code をアンインストール
@@ -138,7 +138,7 @@ uninstall-claude-code: ## Claude Code をアンインストール
 
 .PHONY: mcp-setup
 mcp-setup: ## MCPサーバーをClaude Codeにグローバル登録
-	./scripts/mcp_setup.sh
+	mise exec -- ./scripts/mcp_setup.sh
 
 .PHONY: mcp-dump
 mcp-dump: ## 現在登録済みのMCPサーバーをmcp-servers.jsonにエクスポート


### PR DESCRIPTION
## Summary

- `make setup` で `install-claude-code` 実行時に `npm が見つかりません` エラーが発生する問題を修正
- `mise exec --` を使って mise 管理下のツール (node/npm/claude) を PATH に注入する

## Root Cause

`make` の各ターゲットは独立した子プロセスで実行されるため、`mise-install` で
インストールした Node.js のシムが後続ターゲットの PATH に継承されない。

```
make setup
  → mise-install  # node@22 をインストール (mise shims に追加)
  → install-claude-code  # 別プロセス。mise shims が PATH にない → npm 見つからず ❌
  → mcp-setup             # 同様に claude コマンドが見つからず ❌
```

## Fix

```makefile
# Before
install-claude-code:
    ./scripts/install_claude_code.sh

# After
install-claude-code:
    mise exec -- ./scripts/install_claude_code.sh
```

`mise exec` は mise が管理するツールのシムを含む PATH でコマンドを実行する。
`mcp-setup` も同様に修正 (claude コマンドが必要なため)。

## Test plan

- [ ] `make setup` で `install-claude-code` がエラーなく完了することを確認
- [ ] CI (macOS Setup Test) が通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)