### PR TITLE
feat: Phase 2 — CI・依存管理の整合性を改善

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -25,7 +25,7 @@
 
 - [ ] `make doctor` でエラーがないことを確認した
 - [ ] `make link-dry` でシンボリックリンクの変更を確認した
-- [ ] `shellcheck scripts/*.sh .config/zsh/*.zsh` を実行した
+- [ ] `make shellcheck` を実行した
 - [ ] 新規 Mac（またはクリーンな環境）でテストした
 
 ## スクリーンショット / ログ

--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -25,9 +25,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Run shellcheck
-        run: |
-          find scripts/ -name "*.sh" -print0 \
-            | xargs -0 shellcheck -e SC1091 --severity=warning
+        run: make shellcheck
 
   # ============================================================
   # macOS セットアップテスト
@@ -108,6 +106,9 @@ jobs:
           make install-claude-code
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
+      # mcp-setup は CI 対象外: claude コマンドの認証状態とローカル設定ファイル
+      # ($XDG_CONFIG_HOME/claude/mcp-servers.json) に依存するため自動テストが困難
+
       - name: Configure Git for CI
         run: |
           git config --global user.name "GitHub Actions"
@@ -118,7 +119,8 @@ jobs:
         run: make git-hooks
 
       - name: Run doctor (environment health check)
-        run: make doctor || true  # 警告があっても CI は継続
+        run: make doctor
+        # doctor.sh は WARN(exit 0) と FAIL(exit 1) を区別する。WARN は CI を継続し、FAIL だけ落とす
 
       - name: Run shellcheck (zsh configs)
         run: make shellcheck

--- a/Makefile
+++ b/Makefile
@@ -168,4 +168,5 @@ git-hooks: ## グローバル Git フック（core.hooksPath）を設定する
 
 .PHONY: shellcheck
 shellcheck: ## シェルスクリプト・Zsh 設定ファイルの構文チェック
-	shellcheck ./**/*.sh ./.config/zsh/.zshrc ./.config/zsh/.zshenv ./.local/**/**/*.sh
+	find scripts/ -name "*.sh" -print0 | xargs -0 shellcheck -e SC1091 --severity=warning
+	shellcheck -e SC1091 --severity=warning .config/zsh/.zshrc .config/zsh/.zshenv

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -203,7 +203,7 @@ fi
 # ----------- Homebrew パッケージ -----------
 section "Homebrew パッケージ"
 if command -v brew >/dev/null 2>&1; then
-  for brewfile_name in Brewfile Brewfile.cask; do
+  for brewfile_name in Brewfile Brewfile.taps Brewfile.cask Brewfile.vscode; do
     file="$BASE_DIR/.config/homebrew/$brewfile_name"
     if [ -f "$file" ]; then
       if brew bundle check --file="$file" --quiet 2>/dev/null; then

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -176,7 +176,7 @@ if [ -n "$git_hooks" ]; then
   # ~ はクォート内で展開されないため $HOME に置換して評価する
   git_hooks_expanded="${git_hooks/#\~/$HOME}"
   if [ -d "$git_hooks_expanded" ]; then
-    hook_count=$(find "$git_hooks_expanded" -maxdepth 1 -type f -perm /111 2>/dev/null | wc -l | tr -d ' ')
+    hook_count=$(find "$git_hooks_expanded" -maxdepth 1 -type f -perm /111 2>/dev/null | wc -l | tr -d ' ' || echo "0")
     ok "core.hooksPath: ${git_hooks}（${hook_count}件の実行可能フック）"
   else
     warn "core.hooksPath が設定されていますがディレクトリが存在しません: $git_hooks"


### PR DESCRIPTION
## Summary

Plans.md Phase 2 の全タスク (2.1〜2.5) を実装します。

## 変更内容

### 2.1 — CI shellcheck ジョブを `make shellcheck` に統一
CI と `make shellcheck` のカバレッジが乖離していた問題を解消。
`Makefile` の `shellcheck` ターゲットも `find` ベースに更新し、`scripts/*.sh` と zsh 設定ファイルを同一オプション (`-e SC1091 --severity=warning`) で検査するよう統一。

### 2.2 — `make doctor || true` を削除して FAIL を CI で検知
`doctor.sh` は WARN(exit 0) / FAIL(exit 1) を既に区別しているため、`|| true` を外すだけで FAIL のみ CI を落とす挙動になる。WARN（推奨ツール未インストールなど）は CI を継続する。

### 2.3 — doctor.sh の Brewfile 検証対象を拡張
`Brewfile` / `Brewfile.cask` のみだった検証対象に `Brewfile.taps` / `Brewfile.vscode` を追加。
（`Brewfile.mas` は Mac App Store 認証が必要なため対象外）

### 2.4 — PR テンプレートの shellcheck 項目を `make shellcheck` に統一
ローカル実行コマンドと CI を一致させる。

### 2.5 — CI に mcp-setup を含まない理由をコメントで明文化
`claude` コマンドの認証状態と `mcp-servers.json` に依存するため CI 対象外であることをコメントに記載。

## Test plan

- [ ] Shellcheck ジョブが `make shellcheck` 経由で通ること
- [ ] macOS Setup Test の doctor ステップが `|| true` なしで通ること
- [ ] CI (Shellcheck + macOS Setup Test) が両方グリーンになること

🤖 Generated with [Claude Code](https://claude.com/claude-code)