### PR TITLE
feat: Phase 3 — XDG 準拠・ドキュメント整合

### DIFF
--- a/.config/python/pythonrc
+++ b/.config/python/pythonrc
@@ -14,7 +14,7 @@ def setup_history():
     else:
         state_home = Path.home() / '.local' / 'state'
 
-    history: Path = state_home / 'python_history'
+    history: Path = state_home / 'python' / 'history'
 
     readline.read_history_file(str(history))
     atexit.register(readline.write_history_file, str(history))

--- a/.config/zsh/.zshrc
+++ b/.config/zsh/.zshrc
@@ -23,11 +23,21 @@ fi
 # sheldon
 command -v sheldon &>/dev/null && eval "$(sheldon source)"
 
-# gcloud
+# gcloud（インストール済みの場合のみ読み込む）
 # shellcheck disable=SC1091
-if [ -f "$HOME/google-cloud-sdk/path.zsh.inc" ]; then . "$HOME/google-cloud-sdk/path.zsh.inc"; fi
-# shellcheck disable=SC1091
-if [ -f "$HOME/google-cloud-sdk/completion.zsh.inc" ]; then . "$HOME/google-cloud-sdk/completion.zsh.inc"; fi
+if command -v gcloud &>/dev/null; then
+  GCLOUD_SDK_ROOT="${CLOUDSDK_ROOT_DIR:-$HOME/google-cloud-sdk}"
+  if [ -f "$GCLOUD_SDK_ROOT/path.zsh.inc" ]; then . "$GCLOUD_SDK_ROOT/path.zsh.inc"; fi
+  # 補完は lazy load（初回 tab 補完時に初期化）
+  if [ -f "$GCLOUD_SDK_ROOT/completion.zsh.inc" ]; then
+    gcloud_completion_load() {
+      # shellcheck disable=SC1091
+      . "$GCLOUD_SDK_ROOT/completion.zsh.inc"
+      compdef _gcloud gcloud
+    }
+    compdef gcloud_completion_load gcloud 2>/dev/null || true
+  fi
+fi
 
 # iterm2
 # shellcheck disable=SC1091

--- a/README.md
+++ b/README.md
@@ -29,10 +29,18 @@ Macの環境構築および設定ファイル（dotfiles）を管理するリポ
 ```
 
 このコマンド一発で以下をすべて自動実行します:
-1. macOS バージョン確認
+1. macOS バージョン確認（13 Ventura 以上を推奨）
 2. Xcode Command Line Tools インストール
 3. dotfiles リポジトリを `~/dotfiles` に clone
-4. `make setup` 実行（Homebrew・シンボリックリンク・パッケージ・macOS 設定・クラウドツール）
+4. `make install`（Homebrew・Rosetta・XDG ディレクトリ・yq）
+5. `make link`（シンボリックリンク作成）
+6. `make brew-bundle-taps` / `make brew-bundle` / `make brew-bundle-cask` / `make brew-bundle-vscode`（Homebrew パッケージ）
+7. `make sheldon`（Zsh プラグイン初期化）
+8. `make mac-defaults`（macOS システム設定）
+9. AWS CLI / Google Cloud SDK / Claude Code インストール（失敗時はスキップ）
+
+> **注意**: `make setup` で呼ばれる `mise-install`・`git-hooks`・`mcp-setup` は bootstrap フローに含まれません。
+> これらはローカル環境依存のため、セットアップ完了後に手動で `make setup` を実行するか、個別に実行してください。
 
 ### 既存環境への適用
 
@@ -203,7 +211,7 @@ make backup
 make link
 ```
 
-バックアップは `~/.dotfiles-backup/YYYYMMDD_HHMMSS/` に保存されます。
+バックアップは `~/.local/state/dotfiles/YYYYMMDD_HHMMSS/`（`$XDG_STATE_HOME/dotfiles/`）に保存されます。
 
 ### シンボリックリンクを元に戻したい
 

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 BASE_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 LINK_MAP="$BASE_DIR/.config/link_map.yaml"
 TIMESTAMP=$(date +%Y%m%d_%H%M%S)
-BACKUP_DIR="$HOME/.dotfiles-backup/$TIMESTAMP"
+BACKUP_DIR="${XDG_STATE_HOME:-$HOME/.local/state}/dotfiles/$TIMESTAMP"
 
 command -v yq >/dev/null 2>&1 || { echo "Error: yq が必要です。brew install yq でインストールしてください。" >&2; exit 1; }
 

--- a/scripts/mac_defaults.sh
+++ b/scripts/mac_defaults.sh
@@ -108,7 +108,7 @@ success "Finder"
 # スクリーンショット
 # ============================================================
 log "スクリーンショットを設定しています..."
-SCREENSHOT_DIR="$HOME/screenshots"
+SCREENSHOT_DIR="${XDG_PICTURES_DIR:-$HOME/Pictures}/Screenshots"
 mkdir -p "$SCREENSHOT_DIR"
 defaults write com.apple.screencapture location    "$SCREENSHOT_DIR"
 defaults write com.apple.screencapture type        -string "png"


### PR DESCRIPTION
## Summary

- `scripts/mac_defaults.sh`: スクリーンショット保存先を `~/screenshots` → `${XDG_PICTURES_DIR:-$HOME/Pictures}/Screenshots` に変更（`~` 直下を汚さない）
- `scripts/backup.sh`: バックアップ先を `~/.dotfiles-backup` → `${XDG_STATE_HOME:-$HOME/.local/state}/dotfiles` に変更
- `.config/python/pythonrc`: Python 履歴パスを `python_history` → `python/history` に修正（`install.sh` の `mkdir -p $HOME/.local/state/python` と統一）
- `.config/zsh/.zshrc`: gcloud 読み込みを `command -v gcloud` ガード付きに変更し、補完を lazy load 化（未インストール環境でのシェル起動失敗を防止）
- `README.md`: bootstrap.sh の実挙動（個別 make ターゲット呼び出し）に合わせてクイックスタート説明を修正、バックアップパス記載も更新

## Test plan

- [ ] `make shellcheck` がローカルで通ること
- [ ] CI の shellcheck ジョブが通ること
- [ ] CI の macOS Setup Test が通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)